### PR TITLE
Automatically set API URL

### DIFF
--- a/utils/settings.js
+++ b/utils/settings.js
@@ -1,4 +1,6 @@
-export const API_URL = "https://gameideagenerator.azurewebsites.net/api/"
-//export const API_URL = "http://localhost:8080/api/"
+// Check if the API is running locally or on Azure and set the API_URL accordingly
+export const API_URL = (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") ?
+    "http://localhost:8080/api/" :
+    "https://gameideagenerator.azurewebsites.net/api/"
 
 export const FETCH_NO_API_ERROR = " (Is the API online or does the endpoint exist?)" 


### PR DESCRIPTION
Automatically set API URL to improve stability of the flow between working in development and releasing to production:
- We avoid anyone forgetting to add the production URL before deploying (if the production URL was commented out to use the development URL).
- We don't have to change the URL actively between development and deployment.